### PR TITLE
[BE]: Student Citizenship management 

### DIFF
--- a/backend/src/main/java/com/tkpm/sms/dto/request/StudentCreateRequestDto.java
+++ b/backend/src/main/java/com/tkpm/sms/dto/request/StudentCreateRequestDto.java
@@ -45,4 +45,7 @@ public class StudentCreateRequestDto {
 
     @StatusConstraint(message = "INVALID_STATUS")
     String status = Status.Studying.name();
+
+    @NotNull
+    String citizenship;
 }

--- a/backend/src/main/java/com/tkpm/sms/dto/request/StudentUpdateRequestDto.java
+++ b/backend/src/main/java/com/tkpm/sms/dto/request/StudentUpdateRequestDto.java
@@ -42,4 +42,7 @@ public class StudentUpdateRequestDto {
 
     @StatusConstraint(message = "INVALID_STATUS")
     String status = Status.Studying.name();
+
+    @NotNull
+    String citizenship;
 }

--- a/backend/src/main/java/com/tkpm/sms/dto/response/student/StudentDto.java
+++ b/backend/src/main/java/com/tkpm/sms/dto/response/student/StudentDto.java
@@ -2,6 +2,7 @@ package com.tkpm.sms.dto.response.student;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.tkpm.sms.entity.Address;
+import com.tkpm.sms.entity.Citizenship;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
@@ -30,4 +31,6 @@ public class StudentDto {
     Address permanentAddress;
     Address temporaryAddress;
     Address mailingAddress;
+
+    String citizenship;
 }

--- a/backend/src/main/java/com/tkpm/sms/dto/response/student/StudentMinimalDto.java
+++ b/backend/src/main/java/com/tkpm/sms/dto/response/student/StudentMinimalDto.java
@@ -2,6 +2,7 @@ package com.tkpm.sms.dto.response.student;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.tkpm.sms.entity.Address;
+import com.tkpm.sms.entity.Citizenship;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
@@ -27,4 +28,6 @@ public class StudentMinimalDto {
     String email;
     String phone;
     String status;
+
+    String citizenship;
 }

--- a/backend/src/main/java/com/tkpm/sms/entity/Citizenship.java
+++ b/backend/src/main/java/com/tkpm/sms/entity/Citizenship.java
@@ -1,0 +1,26 @@
+package com.tkpm.sms.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Builder
+@Getter
+@Setter
+@Entity
+@Table(name = "citizenships")
+@AllArgsConstructor
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class Citizenship {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    String id;
+    @Column(name = "country_name")
+    String countryName;
+
+    @OneToMany(mappedBy = "citizenship")
+    List<Student> students;
+}

--- a/backend/src/main/java/com/tkpm/sms/entity/Student.java
+++ b/backend/src/main/java/com/tkpm/sms/entity/Student.java
@@ -75,4 +75,8 @@ public class Student {
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "mailing_address_id")
     Address mailingAddress;
+
+    @ManyToOne
+    @JoinColumn(name = "citizenship_id")
+    Citizenship citizenship;
 }

--- a/backend/src/main/java/com/tkpm/sms/mapper/CitizenshipMapper.java
+++ b/backend/src/main/java/com/tkpm/sms/mapper/CitizenshipMapper.java
@@ -1,0 +1,13 @@
+package com.tkpm.sms.mapper;
+import org.mapstruct.Mapper;
+
+import com.tkpm.sms.entity.Citizenship;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface CitizenshipMapper {
+    Citizenship createCitizenship(String countryName);
+    void updateCitizenship(@MappingTarget Citizenship citizenship, String countryName);
+}

--- a/backend/src/main/java/com/tkpm/sms/mapper/StudentMapper.java
+++ b/backend/src/main/java/com/tkpm/sms/mapper/StudentMapper.java
@@ -5,15 +5,18 @@ import com.tkpm.sms.dto.request.StudentUpdateRequestDto;
 import com.tkpm.sms.dto.response.student.StudentDto;
 import com.tkpm.sms.dto.response.student.StudentMinimalDto;
 import com.tkpm.sms.entity.Student;
+import lombok.RequiredArgsConstructor;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 
 @Mapper(componentModel = "spring")
 public interface StudentMapper {
+    @Mapping(target = "citizenship", source = "citizenship.countryName")
     StudentDto toStudentDto(Student student);
+
+    @Mapping(target = "citizenship", source = "citizenship.countryName")
     StudentMinimalDto toStudentMinimalDto(Student student);
-    Student toStudent(StudentDto studentDto);
 
     @Mapping(target = "status", ignore = true)
     @Mapping(target = "faculty", ignore = true)
@@ -21,10 +24,12 @@ public interface StudentMapper {
     @Mapping(target = "mailingAddress", ignore = true)
     @Mapping(target = "temporaryAddress", ignore = true)
     @Mapping(target = "permanentAddress", ignore = true)
+    @Mapping(target = "citizenship", ignore = true)
     void updateStudent(@MappingTarget Student student, StudentUpdateRequestDto request);
 
     @Mapping(target = "status", ignore = true)
     @Mapping(target = "faculty", ignore = true)
     @Mapping(target = "gender", ignore = true)
+    @Mapping(target = "citizenship", ignore = true)
     Student createStudent(StudentCreateRequestDto request);
 }

--- a/backend/src/main/java/com/tkpm/sms/repository/CitizenshipRepository.java
+++ b/backend/src/main/java/com/tkpm/sms/repository/CitizenshipRepository.java
@@ -1,0 +1,10 @@
+package com.tkpm.sms.repository;
+
+import com.tkpm.sms.entity.Citizenship;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CitizenshipRepository extends JpaRepository<Citizenship, String> {
+    Optional<Citizenship> findCitizenshipByCountryNameEqualsIgnoreCase(String normalizedName);
+}

--- a/backend/src/main/java/com/tkpm/sms/service/CitizenshipService.java
+++ b/backend/src/main/java/com/tkpm/sms/service/CitizenshipService.java
@@ -1,0 +1,55 @@
+package com.tkpm.sms.service;
+
+import com.tkpm.sms.entity.Citizenship;
+import com.tkpm.sms.mapper.CitizenshipMapper;
+import com.tkpm.sms.repository.CitizenshipRepository;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class CitizenshipService {
+    CitizenshipMapper citizenshipMapper;
+    CitizenshipRepository citizenshipRepository;
+
+    public Citizenship createOrGetCitizenship(String name) {
+        if (name == null || name.isBlank()) {
+            return null;
+        }
+
+        // Normalize country name to prevent duplicates with different casing
+        String normalizedName = normalizeCountryName(name);
+
+        // Try to find existing citizenship first
+        return citizenshipRepository.findCitizenshipByCountryNameEqualsIgnoreCase(normalizedName)
+                .orElseGet(() -> {
+                    // Create new if not found
+                    Citizenship citizenship = citizenshipMapper.createCitizenship(normalizedName);
+                    return citizenshipRepository.save(citizenship);
+                });
+    }
+
+    private String normalizeCountryName(String name) {
+        if (name == null || name.isBlank()) {
+            return "";
+        }
+
+        String[] words = name.trim().toLowerCase().split("\\s+");
+        StringBuilder result = new StringBuilder();
+
+        for (String word : words) {
+            if (!word.isEmpty()) {
+                if (result.length() > 0) {
+                    result.append(" ");
+                }
+                result.append(Character.toUpperCase(word.charAt(0)))
+                        .append(word.substring(1));
+            }
+        }
+
+        return result.toString();
+    }
+}

--- a/backend/src/main/java/com/tkpm/sms/service/StudentService.java
+++ b/backend/src/main/java/com/tkpm/sms/service/StudentService.java
@@ -34,6 +34,8 @@ public class StudentService {
     AddressService addressService;
     AddressMapper addressMapper;
 
+    CitizenshipService citizenshipService;
+
     public Page<Student> findAll(int page, String sortName, String sortType, String search) {
         Pageable pageable = PageRequest.of(page - 1, PAGE_SIZE,
                 Sort.by(sortType.equals("asc") ? Sort.Direction.ASC : Sort.Direction.DESC,
@@ -80,6 +82,10 @@ public class StudentService {
         student.setStatus(Status.valueOf(studentCreateRequestDto.getStatus()));
         student.setFaculty(Faculty.fromString(studentCreateRequestDto.getFaculty()));
         student.setGender(Gender.valueOf(studentCreateRequestDto.getGender()));
+
+        student.setCitizenship(
+                citizenshipService.createOrGetCitizenship(studentCreateRequestDto.getCitizenship())
+        );
 
         student = studentRepository.save(student);
         return student;
@@ -164,6 +170,10 @@ public class StudentService {
                 student.setMailingAddress(newMailingAddress);
             }
         }
+
+        student.setCitizenship(
+                citizenshipService.createOrGetCitizenship(studentUpdateRequestDto.getCitizenship())
+        );
 
         student = studentRepository.save(student);
 

--- a/backend/src/main/resources/db/migration/initial-schema.sql
+++ b/backend/src/main/resources/db/migration/initial-schema.sql
@@ -19,6 +19,13 @@ CREATE TABLE identities
     CONSTRAINT pk_identities PRIMARY KEY (id)
 );
 
+CREATE TABLE citizenships
+(
+    id           VARCHAR(255) NOT NULL,
+    country_name VARCHAR(255),
+    CONSTRAINT pk_citizenships PRIMARY KEY (id)
+);
+
 CREATE TABLE students
 (
     id                   VARCHAR(255) NOT NULL,
@@ -36,6 +43,7 @@ CREATE TABLE students
     temporary_address_id VARCHAR(255),
     mailing_address_id   VARCHAR(255),
     identity_id          VARCHAR(255),
+    citizenship_id       VARCHAR(255),
     CONSTRAINT pk_students PRIMARY KEY (id)
 );
 
@@ -59,6 +67,9 @@ ALTER TABLE students
 
 ALTER TABLE students
     ADD CONSTRAINT uc_students_temporary_address UNIQUE (temporary_address_id);
+
+ALTER TABLE students
+    ADD CONSTRAINT FK_STUDENTS_ON_CITIZENSHIP FOREIGN KEY (citizenship_id) REFERENCES citizenships (id);
 
 ALTER TABLE students
     ADD CONSTRAINT FK_STUDENTS_ON_IDENTITY FOREIGN KEY (identity_id) REFERENCES identities (id);


### PR DESCRIPTION
### Key feature:
* Citizenship is now added
* When create and update student, there another information that we need to inform is Citizenship. Now we only need to add name of the country.

### Entity and DTO Updates:
* Added the `Citizenship` entity with fields `id`, `countryName`, and a relationship to `Student`.
* Added a `citizenship` field into student related dtos with a `@NotNull` constraint.
* 
### Mapper Updates:
* Updated the `StudentMapper` to map the `citizenship` field and added necessary mappings for `createStudent` and `updateStudent` methods. 
* Added a new `CitizenshipMapper` interface for mapping citizenship data.

### Service Updates:
* Added a new `CitizenshipService` to handle the creation and retrieval of citizenship data.
* Updated the `StudentService` to set the `citizenship` field when creating or updating a student.

### Repository:
* Added a new `CitizenshipRepository` for accessing citizenship data.