### PR TITLE
Feat: CRUD for Subject

### DIFF
--- a/backend/src/main/java/com/tkpm/sms/application/dto/request/faculty/FacultyRequestDto.java
+++ b/backend/src/main/java/com/tkpm/sms/application/dto/request/faculty/FacultyRequestDto.java
@@ -1,5 +1,6 @@
 package com.tkpm.sms.application.dto.request.faculty;
 
+import com.tkpm.sms.application.annotation.RequiredConstraint;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
@@ -10,6 +11,6 @@ import lombok.experimental.FieldDefaults;
 @NoArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class FacultyRequestDto {
-    @NotEmpty(message = "NOT_NULL;Faculty's name is required")
+    @RequiredConstraint(field = "Faculty's name")
     String name;
 }

--- a/backend/src/main/java/com/tkpm/sms/application/dto/request/program/ProgramRequestDto.java
+++ b/backend/src/main/java/com/tkpm/sms/application/dto/request/program/ProgramRequestDto.java
@@ -1,5 +1,6 @@
 package com.tkpm.sms.application.dto.request.program;
 
+import com.tkpm.sms.application.annotation.RequiredConstraint;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
@@ -10,6 +11,6 @@ import lombok.experimental.FieldDefaults;
 @NoArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class ProgramRequestDto {
-    @NotEmpty(message = "NOT_NULL;Program's name is required")
+    @RequiredConstraint(message = "Program's name")
     String name;
 }

--- a/backend/src/main/java/com/tkpm/sms/application/dto/request/setting/EmailDomainSettingRequestDto.java
+++ b/backend/src/main/java/com/tkpm/sms/application/dto/request/setting/EmailDomainSettingRequestDto.java
@@ -1,10 +1,12 @@
 package com.tkpm.sms.application.dto.request.setting;
 
+import com.tkpm.sms.application.annotation.RequiredConstraint;
 import lombok.Data;
 import lombok.experimental.FieldDefaults;
 
 @Data
 @FieldDefaults(level = lombok.AccessLevel.PRIVATE)
 public class EmailDomainSettingRequestDto {
+    @RequiredConstraint(field = "Email domain")
     String domain;
 }

--- a/backend/src/main/java/com/tkpm/sms/application/dto/request/status/StatusRequestDto.java
+++ b/backend/src/main/java/com/tkpm/sms/application/dto/request/status/StatusRequestDto.java
@@ -1,5 +1,6 @@
 package com.tkpm.sms.application.dto.request.status;
 
+import com.tkpm.sms.application.annotation.RequiredConstraint;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
@@ -12,7 +13,7 @@ import java.util.List;
 @NoArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class StatusRequestDto {
-    @NotEmpty(message = "NOT_NULL;Status's name is required")
+    @RequiredConstraint(field = "Status's name")
     String name;
 
     List<Integer> validTransitionIds;

--- a/backend/src/main/java/com/tkpm/sms/application/dto/request/status/StatusVerificationDto.java
+++ b/backend/src/main/java/com/tkpm/sms/application/dto/request/status/StatusVerificationDto.java
@@ -1,5 +1,6 @@
 package com.tkpm.sms.application.dto.request.status;
 
+import com.tkpm.sms.application.annotation.RequiredConstraint;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
@@ -10,10 +11,10 @@ import lombok.experimental.FieldDefaults;
 @NoArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class StatusVerificationDto {
-    @NotEmpty(message = "NOT_NULL;fromId is required")
+    @RequiredConstraint(field = "fromId")
     Integer fromId;
 
-    @NotEmpty(message = "NOT_NULL;toId is required")
+    @RequiredConstraint(field = "toId")
     Integer toId;
 }
 

--- a/backend/src/main/java/com/tkpm/sms/application/dto/request/subject/SubjectRequestDto.java
+++ b/backend/src/main/java/com/tkpm/sms/application/dto/request/subject/SubjectRequestDto.java
@@ -2,6 +2,7 @@ package com.tkpm.sms.application.dto.request.subject;
 
 import com.tkpm.sms.application.annotation.RequiredConstraint;
 import com.tkpm.sms.domain.model.Faculty;
+import jakarta.validation.constraints.Min;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
@@ -13,18 +14,18 @@ import java.util.List;
 @NoArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class SubjectRequestDto {
-    @RequiredConstraint(field = "Subject's name")
+    @RequiredConstraint(field = "name")
     String name;
 
-    @RequiredConstraint(field = "Subject's code")
+    @RequiredConstraint(field = "code")
     String code;
 
     String description;
 
-    @RequiredConstraint(field = "Subject's credits")
+    @RequiredConstraint(field = "credits")
     Integer credits;
 
     Integer facultyId;
 
-    List<String> prerequisites;
+    List<Integer> prerequisitesId;
 }

--- a/backend/src/main/java/com/tkpm/sms/application/dto/request/subject/SubjectRequestDto.java
+++ b/backend/src/main/java/com/tkpm/sms/application/dto/request/subject/SubjectRequestDto.java
@@ -1,0 +1,30 @@
+package com.tkpm.sms.application.dto.request.subject;
+
+import com.tkpm.sms.application.annotation.RequiredConstraint;
+import com.tkpm.sms.domain.model.Faculty;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class SubjectRequestDto {
+    @RequiredConstraint(field = "Subject's name")
+    String name;
+
+    @RequiredConstraint(field = "Subject's code")
+    String code;
+
+    String description;
+
+    @RequiredConstraint(field = "Subject's credits")
+    Integer credits;
+
+    Integer facultyId;
+
+    List<String> prerequisites;
+}

--- a/backend/src/main/java/com/tkpm/sms/application/dto/response/subject/PrerequisiteSubjectDto.java
+++ b/backend/src/main/java/com/tkpm/sms/application/dto/response/subject/PrerequisiteSubjectDto.java
@@ -3,15 +3,13 @@ package com.tkpm.sms.application.dto.response.subject;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
-import java.util.List;
-
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @FieldDefaults(level = AccessLevel.PRIVATE)
-public class PrerequisitesSubjects {
+public class PrerequisiteSubjectDto {
     Integer id;
     String name;
     String code;

--- a/backend/src/main/java/com/tkpm/sms/application/dto/response/subject/PrerequisitesSubjects.java
+++ b/backend/src/main/java/com/tkpm/sms/application/dto/response/subject/PrerequisitesSubjects.java
@@ -1,0 +1,18 @@
+package com.tkpm.sms.application.dto.response.subject;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class PrerequisitesSubjects {
+    Integer id;
+    String name;
+    String code;
+}

--- a/backend/src/main/java/com/tkpm/sms/application/dto/response/subject/SubjectDto.java
+++ b/backend/src/main/java/com/tkpm/sms/application/dto/response/subject/SubjectDto.java
@@ -18,5 +18,5 @@ public class SubjectDto {
     String description;
     Integer credits;
     String faculty;
-    List<PrerequisitesSubjects> prerequisitesSubjects;
+    List<PrerequisiteSubjectDto> prerequisitesSubjects;
 }

--- a/backend/src/main/java/com/tkpm/sms/application/dto/response/subject/SubjectDto.java
+++ b/backend/src/main/java/com/tkpm/sms/application/dto/response/subject/SubjectDto.java
@@ -1,5 +1,6 @@
 package com.tkpm.sms.application.dto.response.subject;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
@@ -11,6 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 @Builder
 @FieldDefaults(level = AccessLevel.PRIVATE)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SubjectDto {
     Integer id;
     String name;

--- a/backend/src/main/java/com/tkpm/sms/application/dto/response/subject/SubjectDto.java
+++ b/backend/src/main/java/com/tkpm/sms/application/dto/response/subject/SubjectDto.java
@@ -1,0 +1,22 @@
+package com.tkpm.sms.application.dto.response.subject;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class SubjectDto {
+    Integer id;
+    String name;
+    String code;
+    String description;
+    Integer credits;
+    String faculty;
+    List<PrerequisitesSubjects> prerequisitesSubjects;
+}

--- a/backend/src/main/java/com/tkpm/sms/application/mapper/SubjectMapper.java
+++ b/backend/src/main/java/com/tkpm/sms/application/mapper/SubjectMapper.java
@@ -1,7 +1,6 @@
 package com.tkpm.sms.application.mapper;
 
 import com.tkpm.sms.application.dto.request.subject.SubjectRequestDto;
-import com.tkpm.sms.application.dto.response.subject.PrerequisitesSubjects;
 import com.tkpm.sms.application.dto.response.subject.SubjectDto;
 import com.tkpm.sms.domain.model.Subject;
 

--- a/backend/src/main/java/com/tkpm/sms/application/mapper/SubjectMapper.java
+++ b/backend/src/main/java/com/tkpm/sms/application/mapper/SubjectMapper.java
@@ -1,0 +1,14 @@
+package com.tkpm.sms.application.mapper;
+
+import com.tkpm.sms.application.dto.request.subject.SubjectRequestDto;
+import com.tkpm.sms.application.dto.response.subject.PrerequisitesSubjects;
+import com.tkpm.sms.application.dto.response.subject.SubjectDto;
+import com.tkpm.sms.domain.model.Subject;
+
+public interface SubjectMapper {
+    Subject toSubject(SubjectRequestDto subjectRequestDto);
+
+    SubjectDto toSubjectDto(Subject subject);
+
+    void updateSubjectFromDto(SubjectRequestDto subjectRequestDto, Subject subject);
+}

--- a/backend/src/main/java/com/tkpm/sms/application/service/implementation/SubjectServiceImpl.java
+++ b/backend/src/main/java/com/tkpm/sms/application/service/implementation/SubjectServiceImpl.java
@@ -3,6 +3,7 @@ package com.tkpm.sms.application.service.implementation;
 import com.tkpm.sms.application.dto.request.common.BaseCollectionRequest;
 import com.tkpm.sms.application.dto.request.subject.SubjectRequestDto;
 import com.tkpm.sms.application.mapper.SubjectMapper;
+import com.tkpm.sms.application.service.interfaces.FacultyService;
 import com.tkpm.sms.application.service.interfaces.SubjectService;
 import com.tkpm.sms.domain.common.PageRequest;
 import com.tkpm.sms.domain.common.PageResponse;
@@ -16,6 +17,8 @@ import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -24,6 +27,8 @@ public class SubjectServiceImpl implements SubjectService {
     SubjectRepository subjectRepository;
     SubjectDomainValidator subjectValidator;
     SubjectMapper subjectMapper;
+
+    FacultyService facultyService;
 
     @Override
     public PageResponse<Subject> findAll(BaseCollectionRequest request) {
@@ -50,6 +55,7 @@ public class SubjectServiceImpl implements SubjectService {
     public Subject createSubject(SubjectRequestDto subjectRequestDto) {
         subjectValidator.validateSubjectCodeUniqueness(subjectRequestDto.getCode());
         Subject subject = subjectMapper.toSubject(subjectRequestDto);
+        subject.setFaculty(facultyService.getFacultyById(subjectRequestDto.getFacultyId()));
 
         return subjectRepository.save(subject);
     }

--- a/backend/src/main/java/com/tkpm/sms/application/service/implementation/SubjectServiceImpl.java
+++ b/backend/src/main/java/com/tkpm/sms/application/service/implementation/SubjectServiceImpl.java
@@ -1,0 +1,80 @@
+package com.tkpm.sms.application.service.implementation;
+
+import com.tkpm.sms.application.dto.request.common.BaseCollectionRequest;
+import com.tkpm.sms.application.dto.request.subject.SubjectRequestDto;
+import com.tkpm.sms.application.mapper.SubjectMapper;
+import com.tkpm.sms.application.service.interfaces.SubjectService;
+import com.tkpm.sms.domain.common.PageRequest;
+import com.tkpm.sms.domain.common.PageResponse;
+import com.tkpm.sms.domain.exception.ResourceNotFoundException;
+import com.tkpm.sms.domain.model.Subject;
+import com.tkpm.sms.domain.repository.SubjectRepository;
+import com.tkpm.sms.domain.service.validators.SubjectDomainValidator;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class SubjectServiceImpl implements SubjectService {
+    SubjectRepository subjectRepository;
+    SubjectDomainValidator subjectValidator;
+    SubjectMapper subjectMapper;
+
+    @Override
+    public PageResponse<Subject> findAll(BaseCollectionRequest request) {
+        PageRequest pageRequest = PageRequest.builder()
+                .pageNumber(request.getPage())
+                .pageSize(request.getSize())
+                .sortBy(request.getSortBy())
+                .sortDirection("asc".equalsIgnoreCase(request.getSortDirection())
+                        ? PageRequest.SortDirection.ASC
+                        : PageRequest.SortDirection.DESC)
+                .build();
+
+        return subjectRepository.findAll(pageRequest);
+    }
+
+    @Override
+    public Subject getSubjectById(Integer id) {
+        return subjectRepository.findById(id).
+                orElseThrow(() -> new ResourceNotFoundException(
+                        String.format("Subject with id %s not found", id)));
+    }
+
+    @Override
+    public Subject createSubject(SubjectRequestDto subjectRequestDto) {
+        subjectValidator.validateSubjectCodeUniqueness(subjectRequestDto.getCode());
+        Subject subject = subjectMapper.toSubject(subjectRequestDto);
+
+        return subjectRepository.save(subject);
+    }
+
+    @Override
+    public Subject updateSubject(Integer id, SubjectRequestDto subjectRequestDto) {
+        Subject subject = subjectRepository.findById(id).
+                orElseThrow(() -> new ResourceNotFoundException(
+                        String.format("Subject with id %s not found", id)));
+
+        if(!subject.getCode().equals(subjectRequestDto.getCode())) {
+            subjectValidator.validateSubjectCodeUniqueness(subjectRequestDto.getCode());
+        }
+
+        subjectMapper.updateSubjectFromDto(subjectRequestDto, subject);
+
+        return subjectRepository.save(subject);
+    }
+
+    @Override
+    public void deleteSubject(Integer id) {
+        Subject subject = subjectRepository.findById(id).
+                orElseThrow(() -> new ResourceNotFoundException(
+                        String.format("Subject with id %s not found", id)));
+
+        subjectRepository.delete(subject);
+    }
+}

--- a/backend/src/main/java/com/tkpm/sms/application/service/implementation/SubjectServiceImpl.java
+++ b/backend/src/main/java/com/tkpm/sms/application/service/implementation/SubjectServiceImpl.java
@@ -54,6 +54,8 @@ public class SubjectServiceImpl implements SubjectService {
     @Override
     public Subject createSubject(SubjectRequestDto subjectRequestDto) {
         subjectValidator.validateSubjectCodeUniqueness(subjectRequestDto.getCode());
+        subjectValidator.validateSubjectNameUniqueness(subjectRequestDto.getName());
+
         Subject subject = subjectMapper.toSubject(subjectRequestDto);
         subject.setFaculty(facultyService.getFacultyById(subjectRequestDto.getFacultyId()));
 
@@ -62,13 +64,13 @@ public class SubjectServiceImpl implements SubjectService {
 
     @Override
     public Subject updateSubject(Integer id, SubjectRequestDto subjectRequestDto) {
+        subjectValidator.validateSubjectNameUniquenessForUpdate(subjectRequestDto.getName(), id);
+        subjectValidator.validateSubjectCodeUniquenessForUpdate(subjectRequestDto.getCode(), id);
+
         Subject subject = subjectRepository.findById(id).
                 orElseThrow(() -> new ResourceNotFoundException(
                         String.format("Subject with id %s not found", id)));
 
-        if(!subject.getCode().equals(subjectRequestDto.getCode())) {
-            subjectValidator.validateSubjectCodeUniqueness(subjectRequestDto.getCode());
-        }
 
         subjectMapper.updateSubjectFromDto(subjectRequestDto, subject);
 

--- a/backend/src/main/java/com/tkpm/sms/application/service/interfaces/SubjectService.java
+++ b/backend/src/main/java/com/tkpm/sms/application/service/interfaces/SubjectService.java
@@ -2,9 +2,10 @@ package com.tkpm.sms.application.service.interfaces;
 
 import com.tkpm.sms.application.dto.request.common.BaseCollectionRequest;
 import com.tkpm.sms.application.dto.request.subject.SubjectRequestDto;
-import com.tkpm.sms.domain.common.PageRequest;
 import com.tkpm.sms.domain.common.PageResponse;
 import com.tkpm.sms.domain.model.Subject;
+
+import java.util.List;
 
 public interface SubjectService {
     PageResponse<Subject> findAll(BaseCollectionRequest request);

--- a/backend/src/main/java/com/tkpm/sms/application/service/interfaces/SubjectService.java
+++ b/backend/src/main/java/com/tkpm/sms/application/service/interfaces/SubjectService.java
@@ -1,0 +1,19 @@
+package com.tkpm.sms.application.service.interfaces;
+
+import com.tkpm.sms.application.dto.request.common.BaseCollectionRequest;
+import com.tkpm.sms.application.dto.request.subject.SubjectRequestDto;
+import com.tkpm.sms.domain.common.PageRequest;
+import com.tkpm.sms.domain.common.PageResponse;
+import com.tkpm.sms.domain.model.Subject;
+
+public interface SubjectService {
+    PageResponse<Subject> findAll(BaseCollectionRequest request);
+
+    Subject getSubjectById(Integer id);
+
+    Subject createSubject(SubjectRequestDto subjectRequestDto);
+
+    Subject updateSubject(Integer id, SubjectRequestDto subjectRequestDto);
+
+    void deleteSubject(Integer id);
+}

--- a/backend/src/main/java/com/tkpm/sms/application/validation/RequiredValidator.java
+++ b/backend/src/main/java/com/tkpm/sms/application/validation/RequiredValidator.java
@@ -4,9 +4,11 @@ import com.tkpm.sms.application.annotation.RequiredConstraint;
 import com.tkpm.sms.domain.exception.ErrorCode;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.Objects;
 
+@Slf4j
 public class RequiredValidator implements ConstraintValidator<RequiredConstraint, Object> {
     @Override
     public void initialize(RequiredConstraint constraintAnnotation) {
@@ -15,17 +17,24 @@ public class RequiredValidator implements ConstraintValidator<RequiredConstraint
 
     @Override
     public boolean isValid(Object value, ConstraintValidatorContext context) {
+
         if (Objects.isNull(value)) {
+            addConstraintViolation(context, context.getDefaultConstraintMessageTemplate());
             return false;
         }
 
         if (value instanceof String && ((String) value).isBlank()) {
-            context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(ErrorCode.FIELD_REQUIRED.name())
-                    .addConstraintViolation();
+            addConstraintViolation(context, context.getDefaultConstraintMessageTemplate());
             return false;
         }
 
         return true;
+    }
+
+    private void addConstraintViolation(ConstraintValidatorContext context, String fieldName) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(ErrorCode.FIELD_REQUIRED.name())
+                .addPropertyNode(fieldName)
+                .addConstraintViolation();
     }
 }

--- a/backend/src/main/java/com/tkpm/sms/domain/model/Subject.java
+++ b/backend/src/main/java/com/tkpm/sms/domain/model/Subject.java
@@ -18,5 +18,5 @@ public class Subject {
     String description;
     Integer credits;
     Faculty faculty;
-    List<String> prerequisites;
+    List<Integer> prerequisitesId;
 }

--- a/backend/src/main/java/com/tkpm/sms/domain/model/Subject.java
+++ b/backend/src/main/java/com/tkpm/sms/domain/model/Subject.java
@@ -3,8 +3,7 @@ package com.tkpm.sms.domain.model;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
-import java.time.LocalDate;
-import java.util.Set;
+import java.util.List;
 
 @Getter
 @Setter
@@ -12,10 +11,12 @@ import java.util.Set;
 @NoArgsConstructor
 @Builder
 @FieldDefaults(level = AccessLevel.PRIVATE)
-public class Faculty {
+public class Subject {
     Integer id;
     String name;
-    LocalDate deletedAt;
-    Set<Student> students;
-    Set<Subject> subjects;
+    String code;
+    String description;
+    Integer credits;
+    Faculty faculty;
+    List<String> prerequisites;
 }

--- a/backend/src/main/java/com/tkpm/sms/domain/repository/SubjectRepository.java
+++ b/backend/src/main/java/com/tkpm/sms/domain/repository/SubjectRepository.java
@@ -19,4 +19,10 @@ public interface SubjectRepository {
     Subject save(Subject subject);
 
     void delete(Subject subject);
+
+    boolean existsByName(String name);
+
+    boolean existsByNameAndIdNot(String name, Integer id);
+
+    boolean existsByCodeAndIdNot(String code, Integer id);
 }

--- a/backend/src/main/java/com/tkpm/sms/domain/repository/SubjectRepository.java
+++ b/backend/src/main/java/com/tkpm/sms/domain/repository/SubjectRepository.java
@@ -1,0 +1,22 @@
+package com.tkpm.sms.domain.repository;
+
+import com.tkpm.sms.application.dto.request.common.BaseCollectionRequest;
+import com.tkpm.sms.domain.common.PageRequest;
+import com.tkpm.sms.domain.common.PageResponse;
+import com.tkpm.sms.domain.model.Subject;
+
+import java.util.Optional;
+
+public interface SubjectRepository {
+    boolean existsByCode(String code);
+
+    Optional<Subject> findById(Integer id);
+
+    PageResponse<Subject> findAll(PageRequest request);
+
+    PageResponse<Subject> findWithFilters(String search, String faculty, PageRequest request);
+
+    Subject save(Subject subject);
+
+    void delete(Subject subject);
+}

--- a/backend/src/main/java/com/tkpm/sms/domain/service/validators/SubjectDomainValidator.java
+++ b/backend/src/main/java/com/tkpm/sms/domain/service/validators/SubjectDomainValidator.java
@@ -22,13 +22,27 @@ public class SubjectDomainValidator {
     }
 
     public void validateSubjectCodeUniquenessForUpdate(String code, Integer id) {
-        Optional<Subject> existingSubject = subjectRepository.findById(id);
-        if(existingSubject.isPresent() && !existingSubject.get().getCode().equals(code) ) {
+        if(subjectRepository.existsByCodeAndIdNot(code, id)) {
             throw new DuplicateResourceException(
                     String.format("Subject with code %s already exists", code)
             );
         }
     }
 
+    public void validateSubjectNameUniqueness(String name) {
+        if (subjectRepository.existsByName(name)) {
+            throw new DuplicateResourceException(
+                    String.format("Subject with name %s already exists", name)
+            );
+        }
+    }
+
+    public void validateSubjectNameUniquenessForUpdate(String name, Integer id) {
+        if(subjectRepository.existsByNameAndIdNot(name, id)) {
+            throw new DuplicateResourceException(
+                    String.format("Subject with name %s already exists", name)
+            );
+        }
+    }
 
 }

--- a/backend/src/main/java/com/tkpm/sms/domain/service/validators/SubjectDomainValidator.java
+++ b/backend/src/main/java/com/tkpm/sms/domain/service/validators/SubjectDomainValidator.java
@@ -1,0 +1,34 @@
+package com.tkpm.sms.domain.service.validators;
+
+import com.tkpm.sms.domain.exception.DuplicateResourceException;
+import com.tkpm.sms.domain.model.Subject;
+import com.tkpm.sms.domain.repository.SubjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SubjectDomainValidator {
+    private final SubjectRepository subjectRepository;
+
+    public void validateSubjectCodeUniqueness(String code) {
+        if (subjectRepository.existsByCode(code)) {
+            throw new DuplicateResourceException(
+                    String.format("Subject with code %s already exists", code)
+            );
+        }
+    }
+
+    public void validateSubjectCodeUniquenessForUpdate(String code, Integer id) {
+        Optional<Subject> existingSubject = subjectRepository.findById(id);
+        if(existingSubject.isPresent() && !existingSubject.get().getCode().equals(code) ) {
+            throw new DuplicateResourceException(
+                    String.format("Subject with code %s already exists", code)
+            );
+        }
+    }
+
+
+}

--- a/backend/src/main/java/com/tkpm/sms/infrastructure/mapper/SubjectMapperImpl.java
+++ b/backend/src/main/java/com/tkpm/sms/infrastructure/mapper/SubjectMapperImpl.java
@@ -1,7 +1,6 @@
 package com.tkpm.sms.infrastructure.mapper;
 
 import com.tkpm.sms.application.dto.request.subject.SubjectRequestDto;
-import com.tkpm.sms.application.dto.response.subject.PrerequisitesSubjects;
 import com.tkpm.sms.application.dto.response.subject.SubjectDto;
 import com.tkpm.sms.application.mapper.SubjectMapper;
 import com.tkpm.sms.domain.model.Subject;

--- a/backend/src/main/java/com/tkpm/sms/infrastructure/mapper/SubjectMapperImpl.java
+++ b/backend/src/main/java/com/tkpm/sms/infrastructure/mapper/SubjectMapperImpl.java
@@ -12,6 +12,7 @@ import org.mapstruct.MappingTarget;
 public interface SubjectMapperImpl extends SubjectMapper {
 
     @Override
+    @Mapping(target = "faculty", ignore = true)
     Subject toSubject(SubjectRequestDto subjectRequestDto);
 
     @Override

--- a/backend/src/main/java/com/tkpm/sms/infrastructure/mapper/SubjectMapperImpl.java
+++ b/backend/src/main/java/com/tkpm/sms/infrastructure/mapper/SubjectMapperImpl.java
@@ -1,0 +1,24 @@
+package com.tkpm.sms.infrastructure.mapper;
+
+import com.tkpm.sms.application.dto.request.subject.SubjectRequestDto;
+import com.tkpm.sms.application.dto.response.subject.PrerequisitesSubjects;
+import com.tkpm.sms.application.dto.response.subject.SubjectDto;
+import com.tkpm.sms.application.mapper.SubjectMapper;
+import com.tkpm.sms.domain.model.Subject;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface SubjectMapperImpl extends SubjectMapper {
+
+    @Override
+    Subject toSubject(SubjectRequestDto subjectRequestDto);
+
+    @Override
+    @Mapping(target = "faculty", source = "faculty.name")
+    SubjectDto toSubjectDto(Subject subject);
+
+    @Override
+    void updateSubjectFromDto(SubjectRequestDto subjectRequestDto, @MappingTarget Subject subject);
+}

--- a/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/entity/FacultyEntity.java
+++ b/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/entity/FacultyEntity.java
@@ -32,7 +32,9 @@ public class FacultyEntity {
     @Column(name = "deleted_at")
     LocalDate deletedAt;
 
-    //     one-to-many relationship with student
+    //one-to-many relationship with student
     @OneToMany(mappedBy = "faculty")
     Set<StudentEntity> students;
+
+
 }

--- a/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/entity/SubjectEntity.java
+++ b/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/entity/SubjectEntity.java
@@ -1,0 +1,40 @@
+package com.tkpm.sms.infrastructure.persistence.entity;
+
+import com.tkpm.sms.domain.model.Faculty;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.List;
+
+@Entity
+@Table(name = "subjects")
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class SubjectEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Integer id;
+    String name;
+    String code;
+    String description;
+    Integer credits;
+
+    // many-to-one relationship with faculty
+    @ManyToOne
+    @JoinColumn(name = "faculty_id")
+    FacultyEntity faculty;
+
+    // relationship with prerequisite subjects
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(
+            name = "subject_prerequisites",
+            joinColumns = @JoinColumn(name = "subject_id")
+    )
+    @Column(name = "prerequisite_id")
+    List<Integer> prerequisiteIds;
+}

--- a/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/entity/SubjectEntity.java
+++ b/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/entity/SubjectEntity.java
@@ -30,11 +30,11 @@ public class SubjectEntity {
     FacultyEntity faculty;
 
     // relationship with prerequisite subjects
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(
             name = "subject_prerequisites",
             joinColumns = @JoinColumn(name = "subject_id")
     )
     @Column(name = "prerequisite_id")
-    List<Integer> prerequisiteIds;
+    List<Integer> prerequisitesId;
 }

--- a/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/entity/SubjectEntity.java
+++ b/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/entity/SubjectEntity.java
@@ -2,6 +2,8 @@ package com.tkpm.sms.infrastructure.persistence.entity;
 
 import com.tkpm.sms.domain.model.Faculty;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
@@ -19,9 +21,15 @@ public class SubjectEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Integer id;
+    @NotNull
     String name;
+
+    @NotNull
     String code;
     String description;
+
+    @NotNull
+    @Min(2)
     Integer credits;
 
     // many-to-one relationship with faculty

--- a/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/jpa/SubjectJpaRepository.java
+++ b/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/jpa/SubjectJpaRepository.java
@@ -6,4 +6,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface SubjectJpaRepository extends JpaRepository<SubjectEntity, Integer> {
     boolean existsByCode(String code);
+    boolean existsByName(String name);
+    boolean existsByNameAndIdNot(String name, Integer id);
+    boolean existsByCodeAndIdNot(String code, Integer id);
 }

--- a/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/jpa/SubjectJpaRepository.java
+++ b/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/jpa/SubjectJpaRepository.java
@@ -1,0 +1,9 @@
+package com.tkpm.sms.infrastructure.persistence.jpa;
+
+import com.tkpm.sms.infrastructure.persistence.entity.SubjectEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface SubjectJpaRepository extends JpaRepository<SubjectEntity, Integer> {
+    boolean existsByCode(String code);
+}

--- a/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/mapper/SubjectPersistenceMapper.java
+++ b/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/mapper/SubjectPersistenceMapper.java
@@ -1,0 +1,15 @@
+package com.tkpm.sms.infrastructure.persistence.mapper;
+
+import com.tkpm.sms.domain.model.Subject;
+import com.tkpm.sms.infrastructure.persistence.entity.SubjectEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", uses = {
+        FacultyPersistenceMapper.class
+})
+public interface SubjectPersistenceMapper {
+    SubjectEntity toEntity(Subject domain);
+
+    Subject toDomain(SubjectEntity entity);
+}

--- a/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/repository/SubjectRepositoryImpl.java
+++ b/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/repository/SubjectRepositoryImpl.java
@@ -83,4 +83,19 @@ public class SubjectRepositoryImpl implements SubjectRepository {
 
         jpaRepository.delete(subjectEntity);
     }
+
+    @Override
+    public boolean existsByName(String name) {
+        return jpaRepository.existsByName(name);
+    }
+
+    @Override
+    public boolean existsByNameAndIdNot(String name, Integer id) {
+        return jpaRepository.existsByNameAndIdNot(name, id);
+    }
+
+    @Override
+    public boolean existsByCodeAndIdNot(String code, Integer id) {
+        return jpaRepository.existsByCodeAndIdNot(code, id);
+    }
 }

--- a/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/repository/SubjectRepositoryImpl.java
+++ b/backend/src/main/java/com/tkpm/sms/infrastructure/persistence/repository/SubjectRepositoryImpl.java
@@ -1,0 +1,86 @@
+package com.tkpm.sms.infrastructure.persistence.repository;
+
+import com.tkpm.sms.application.dto.request.common.BaseCollectionRequest;
+import com.tkpm.sms.domain.common.PageRequest;
+import com.tkpm.sms.domain.common.PageResponse;
+import com.tkpm.sms.domain.model.Subject;
+import com.tkpm.sms.domain.repository.SubjectRepository;
+import com.tkpm.sms.infrastructure.persistence.entity.SubjectEntity;
+import com.tkpm.sms.infrastructure.persistence.jpa.SubjectJpaRepository;
+import com.tkpm.sms.infrastructure.persistence.mapper.SubjectPersistenceMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class SubjectRepositoryImpl implements SubjectRepository {
+    private final SubjectJpaRepository jpaRepository;
+    private final SubjectPersistenceMapper mapper;
+
+    @Override
+    public boolean existsByCode(String code) {
+        return jpaRepository.existsByCode(code);
+    }
+
+    @Override
+    public Optional<Subject> findById(Integer id) {
+        return jpaRepository.findById(id)
+                .map(mapper::toDomain);
+    }
+
+    @Override
+    public PageResponse<Subject> findAll(PageRequest request) {
+        // Convert domain PageRequest to Spring Pageable
+        Pageable pageable = org.springframework.data.domain.PageRequest.of(
+                request.getPageNumber() - 1,
+                request.getPageSize(),
+                request.getSortDirection() == PageRequest.SortDirection.DESC
+                        ? Sort.Direction.DESC
+                        : Sort.Direction.ASC,
+                request.getSortBy()
+        );
+
+        Page<SubjectEntity> page = jpaRepository.findAll(pageable);
+
+        // Convert Spring Page to domain PageResponse
+        List<Subject> subjects = page.getContent().stream()
+                .map(mapper::toDomain)
+                .collect(Collectors.toList());
+
+        return PageResponse.of(
+                subjects,
+                page.getNumber() + 1, // Convert 0-based to 1-based
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages()
+        );
+    }
+
+    @Override
+    public PageResponse<Subject> findWithFilters(String search, String faculty, PageRequest request) {
+        return null;
+    }
+
+    @Override
+    public Subject save(Subject subject) {
+        SubjectEntity subjectEntity = mapper.toEntity(subject);
+
+        SubjectEntity savedEntity = jpaRepository.save(subjectEntity);
+
+        return mapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public void delete(Subject subject) {
+        SubjectEntity subjectEntity = mapper.toEntity(subject);
+
+        jpaRepository.delete(subjectEntity);
+    }
+}

--- a/backend/src/main/java/com/tkpm/sms/presentation/controller/SubjectController.java
+++ b/backend/src/main/java/com/tkpm/sms/presentation/controller/SubjectController.java
@@ -1,6 +1,7 @@
 package com.tkpm.sms.presentation.controller;
 
 import com.tkpm.sms.application.dto.request.common.BaseCollectionRequest;
+import com.tkpm.sms.application.dto.request.subject.SubjectRequestDto;
 import com.tkpm.sms.application.dto.response.subject.PrerequisiteSubjectDto;
 import com.tkpm.sms.application.dto.response.subject.SubjectDto;
 import com.tkpm.sms.application.dto.response.common.ApplicationResponseDto;
@@ -13,8 +14,10 @@ import com.tkpm.sms.domain.model.Subject;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.List;
 
@@ -24,55 +27,84 @@ import java.util.List;
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class SubjectController {
-     SubjectService subjectService;
-     SubjectMapper subjectMapper;
+    SubjectService subjectService;
+    SubjectMapper subjectMapper;
 
-     @GetMapping({"/", ""})
-     public ResponseEntity<ApplicationResponseDto<ListResponse<SubjectDto>>> getSubjects(
-             @ModelAttribute BaseCollectionRequest request
-     ) {
-         PageResponse<Subject> pageResponse = subjectService.findAll(request);
+    @GetMapping({"/", ""})
+    public ResponseEntity<ApplicationResponseDto<ListResponse<SubjectDto>>> getSubjects(
+         @ModelAttribute BaseCollectionRequest request
+    ) {
+        PageResponse<Subject> pageResponse = subjectService.findAll(request);
 
-         // Map domain entities to DTOs
-         List<SubjectDto> subjectDtoList = pageResponse.getContent().stream()
-                 .map(subjectMapper::toSubjectDto)
-                 .toList();
+        // Map domain entities to DTOs
+        List<SubjectDto> subjectDtoList = pageResponse.getContent().stream()
+             .map(subjectMapper::toSubjectDto)
+             .toList();
 
-         // Create page info
-         var pageDto = PageDto.builder()
-                 .totalElements(pageResponse.getTotalElements())
-                 .pageSize(pageResponse.getPageSize())
-                 .pageNumber(pageResponse.getPageNumber())
-                 .totalPages(pageResponse.getTotalPages())
-                 .build();
+        // Create page info
+        var pageDto = PageDto.builder()
+             .totalElements(pageResponse.getTotalElements())
+             .pageSize(pageResponse.getPageSize())
+             .pageNumber(pageResponse.getPageNumber())
+             .totalPages(pageResponse.getTotalPages())
+             .build();
 
-         // Create response
-         var listResponse = ListResponse.<SubjectDto>builder()
-                 .page(pageDto)
-                 .data(subjectDtoList)
-                 .build();
+        // Create response
+        var listResponse = ListResponse.<SubjectDto>builder()
+             .page(pageDto)
+             .data(subjectDtoList)
+             .build();
 
-         return ResponseEntity.ok(ApplicationResponseDto.success(listResponse));
-     }
+        return ResponseEntity.ok(ApplicationResponseDto.success(listResponse));
+    }
 
-     @GetMapping("/{id}")
-        public ResponseEntity<ApplicationResponseDto<SubjectDto>> getSubjectById(
-                @PathVariable Integer id
-        ) {
-            Subject subject = subjectService.getSubjectById(id);
+    @GetMapping("/{id}")
+    public ResponseEntity<ApplicationResponseDto<SubjectDto>> getSubjectById(
+            @PathVariable Integer id
+    ) {
+        Subject subject = subjectService.getSubjectById(id);
 
-            List<PrerequisiteSubjectDto> prerequisitesSubjects = subject.getPrerequisitesId().stream()
-                    .map(prerequisiteId -> {
-                        Subject prerequisiteSubject = subjectService.getSubjectById(prerequisiteId);
-                        return new PrerequisiteSubjectDto(
-                                prerequisiteId,
-                                prerequisiteSubject.getName(),
-                                prerequisiteSubject.getCode());
-                    })
-                    .toList();
+        List<PrerequisiteSubjectDto> prerequisitesSubjects = subject.getPrerequisitesId().stream()
+                .map(prerequisiteId -> {
+                    Subject prerequisiteSubject = subjectService.getSubjectById(prerequisiteId);
+                    return new PrerequisiteSubjectDto(
+                            prerequisiteId,
+                            prerequisiteSubject.getName(),
+                            prerequisiteSubject.getCode());
+                })
+                .toList();
 
-            SubjectDto subjectDto = subjectMapper.toSubjectDto(subject);
-            subjectDto.setPrerequisitesSubjects(prerequisitesSubjects);
-            return ResponseEntity.ok(ApplicationResponseDto.success(subjectDto));
-        }
+        SubjectDto subjectDto = subjectMapper.toSubjectDto(subject);
+        subjectDto.setPrerequisitesSubjects(prerequisitesSubjects);
+        return ResponseEntity.ok(ApplicationResponseDto.success(subjectDto));
+    }
+
+    @PostMapping({"/", ""})
+    public ResponseEntity<ApplicationResponseDto<SubjectDto>> createSubject(
+            @RequestBody SubjectRequestDto subjectRequestDto,
+            UriComponentsBuilder uriComponentsBuilder
+    ) {
+        Subject createdSubject = subjectService.createSubject(subjectRequestDto);
+        SubjectDto createdSubjectDto = subjectMapper.toSubjectDto(createdSubject);
+        return ResponseEntity.created(uriComponentsBuilder.path("/api/subjects/{id}").buildAndExpand(createdSubject.getId()).toUri())
+                .body(ApplicationResponseDto.success(createdSubjectDto));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApplicationResponseDto<SubjectDto>> updateSubject(
+            @PathVariable Integer id,
+            @RequestBody SubjectRequestDto subjectRequestDto
+    ) {
+        Subject updatedSubject = subjectService.updateSubject(id, subjectRequestDto);
+        SubjectDto updatedSubjectDto = subjectMapper.toSubjectDto(updatedSubject);
+        return ResponseEntity.ok(ApplicationResponseDto.success(updatedSubjectDto));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApplicationResponseDto<Void>> deleteSubject(
+            @PathVariable Integer id
+    ) {
+        subjectService.deleteSubject(id);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }

--- a/backend/src/main/java/com/tkpm/sms/presentation/controller/SubjectController.java
+++ b/backend/src/main/java/com/tkpm/sms/presentation/controller/SubjectController.java
@@ -11,6 +11,7 @@ import com.tkpm.sms.application.mapper.SubjectMapper;
 import com.tkpm.sms.application.service.interfaces.SubjectService;
 import com.tkpm.sms.domain.common.PageResponse;
 import com.tkpm.sms.domain.model.Subject;
+import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
@@ -81,7 +82,7 @@ public class SubjectController {
 
     @PostMapping({"/", ""})
     public ResponseEntity<ApplicationResponseDto<SubjectDto>> createSubject(
-            @RequestBody SubjectRequestDto subjectRequestDto,
+            @Valid @RequestBody SubjectRequestDto subjectRequestDto,
             UriComponentsBuilder uriComponentsBuilder
     ) {
         Subject createdSubject = subjectService.createSubject(subjectRequestDto);
@@ -93,7 +94,7 @@ public class SubjectController {
     @PutMapping("/{id}")
     public ResponseEntity<ApplicationResponseDto<SubjectDto>> updateSubject(
             @PathVariable Integer id,
-            @RequestBody SubjectRequestDto subjectRequestDto
+            @Valid @RequestBody SubjectRequestDto subjectRequestDto
     ) {
         Subject updatedSubject = subjectService.updateSubject(id, subjectRequestDto);
         SubjectDto updatedSubjectDto = subjectMapper.toSubjectDto(updatedSubject);

--- a/backend/src/main/java/com/tkpm/sms/presentation/controller/SubjectController.java
+++ b/backend/src/main/java/com/tkpm/sms/presentation/controller/SubjectController.java
@@ -1,0 +1,78 @@
+package com.tkpm.sms.presentation.controller;
+
+import com.tkpm.sms.application.dto.request.common.BaseCollectionRequest;
+import com.tkpm.sms.application.dto.response.subject.PrerequisiteSubjectDto;
+import com.tkpm.sms.application.dto.response.subject.SubjectDto;
+import com.tkpm.sms.application.dto.response.common.ApplicationResponseDto;
+import com.tkpm.sms.application.dto.response.common.ListResponse;
+import com.tkpm.sms.application.dto.response.common.PageDto;
+import com.tkpm.sms.application.mapper.SubjectMapper;
+import com.tkpm.sms.application.service.interfaces.SubjectService;
+import com.tkpm.sms.domain.common.PageResponse;
+import com.tkpm.sms.domain.model.Subject;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@CrossOrigin(origins = "http://localhost:5173")
+@RequestMapping("/api/subjects")
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class SubjectController {
+     SubjectService subjectService;
+     SubjectMapper subjectMapper;
+
+     @GetMapping({"/", ""})
+     public ResponseEntity<ApplicationResponseDto<ListResponse<SubjectDto>>> getSubjects(
+             @ModelAttribute BaseCollectionRequest request
+     ) {
+         PageResponse<Subject> pageResponse = subjectService.findAll(request);
+
+         // Map domain entities to DTOs
+         List<SubjectDto> subjectDtoList = pageResponse.getContent().stream()
+                 .map(subjectMapper::toSubjectDto)
+                 .toList();
+
+         // Create page info
+         var pageDto = PageDto.builder()
+                 .totalElements(pageResponse.getTotalElements())
+                 .pageSize(pageResponse.getPageSize())
+                 .pageNumber(pageResponse.getPageNumber())
+                 .totalPages(pageResponse.getTotalPages())
+                 .build();
+
+         // Create response
+         var listResponse = ListResponse.<SubjectDto>builder()
+                 .page(pageDto)
+                 .data(subjectDtoList)
+                 .build();
+
+         return ResponseEntity.ok(ApplicationResponseDto.success(listResponse));
+     }
+
+     @GetMapping("/{id}")
+        public ResponseEntity<ApplicationResponseDto<SubjectDto>> getSubjectById(
+                @PathVariable Integer id
+        ) {
+            Subject subject = subjectService.getSubjectById(id);
+
+            List<PrerequisiteSubjectDto> prerequisitesSubjects = subject.getPrerequisitesId().stream()
+                    .map(prerequisiteId -> {
+                        Subject prerequisiteSubject = subjectService.getSubjectById(prerequisiteId);
+                        return new PrerequisiteSubjectDto(
+                                prerequisiteId,
+                                prerequisiteSubject.getName(),
+                                prerequisiteSubject.getCode());
+                    })
+                    .toList();
+
+            SubjectDto subjectDto = subjectMapper.toSubjectDto(subject);
+            subjectDto.setPrerequisitesSubjects(prerequisitesSubjects);
+            return ResponseEntity.ok(ApplicationResponseDto.success(subjectDto));
+        }
+}

--- a/backend/src/main/java/com/tkpm/sms/presentation/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/tkpm/sms/presentation/error/GlobalExceptionHandler.java
@@ -74,12 +74,18 @@ public class GlobalExceptionHandler {
 
         String enumKey = fieldError.getDefaultMessage();
         ErrorResponseInfo errorInfo = processValidationError(exception, enumKey);
+        HttpStatus status = errorCodeStatusMapper.getStatus(errorInfo.errorCode);
+
+        var response = ApplicationResponseDto.failure(
+                new GenericDomainException(
+                        errorInfo.formattedMessage,
+                        errorInfo.errorCode),
+                status.value()
+        );
 
         return ResponseEntity
                 .badRequest()
-                .body(ApplicationResponseDto.failure(new GenericDomainException(
-                            errorInfo.formattedMessage,
-                            errorInfo.errorCode)));
+                .body(response);
     }
 
     private static class ErrorResponseInfo {


### PR DESCRIPTION
# CRUD FOR SUBJECT

This pull request introduces several new features and improvements related to the `Subject` entity in the backend service. The changes include adding new DTOs, services, mappers, validators, and repository interfaces to handle subject-related operations.

### New Features and Improvements:

*Subject Management:*
- Added `SubjectRequestDto` and `SubjectDto` for handling subject requests and responses 
- Implemented `SubjectService` and its implementation `SubjectServiceImpl` to manage subject operations 
- Created `SubjectMapper` and its implementation using MapStruct for mapping between DTOs and entities 
- Added `SubjectDomainValidator` to ensure the uniqueness of subject codes and names 

*Entity and Repository Enhancements:*
- Introduced `SubjectEntity` and `SubjectRepository` interface for database operations 
- Created `SubjectEntity` and `SubjectJpaRepository` for JPA-based persistence 

These changes collectively enhance the backend service's capability to manage subjects, including creating, updating, and validating subjects, while ensuring data integrity and consistency.